### PR TITLE
Fix lockfile handling

### DIFF
--- a/bup_cron/__init__.py
+++ b/bup_cron/__init__.py
@@ -1082,12 +1082,14 @@ def main():
 
     logging.info('bup-cron %s starting' % __version__)
     try:
+        initialised = False
         if not os.path.exists(os.environ['BUP_DIR']):
             if not Bup.init(args.remote):
                 bail(3, timer, 'failed to initialize bup repo')
+            initialised = True
 
         with Pidfile(args.pidfile):
-            if args.clear:
+            if args.clear and not initialised:
                 if not Bup.clear_index():
                     logging.warning('failed to clear the index')
 

--- a/bup_cron/__init__.py
+++ b/bup_cron/__init__.py
@@ -650,7 +650,7 @@ class Pidfile():
                 else:
                     try:
                         os.remove(self.pidfile)
-                        logging.warn('removed staled lockfile %s'
+                        logging.warn('removed stale lockfile %s'
                                      % (self.pidfile))
                         self.pidfd = os.open(self.pidfile,
                                              os.O_CREAT

--- a/bup_cron/__init__.py
+++ b/bup_cron/__init__.py
@@ -1082,11 +1082,12 @@ def main():
 
     logging.info('bup-cron %s starting' % __version__)
     try:
+        if not os.path.exists(os.environ['BUP_DIR']):
+            if not Bup.init(args.remote):
+                bail(3, timer, 'failed to initialize bup repo')
+
         with Pidfile(args.pidfile):
-            if not os.path.exists(os.environ['BUP_DIR']):
-                if not Bup.init(args.remote):
-                    bail(3, timer, 'failed to initialize bup repo')
-            elif args.clear:
+            if args.clear:
                 if not Bup.clear_index():
                     logging.warning('failed to clear the index')
 

--- a/bup_cron/__init__.py
+++ b/bup_cron/__init__.py
@@ -1086,10 +1086,9 @@ def main():
             if not os.path.exists(os.environ['BUP_DIR']):
                 if not Bup.init(args.remote):
                     bail(3, timer, 'failed to initialize bup repo')
-            else:
-                if args.clear:
-                    if not Bup.clear_index():
-                        logging.warning('failed to clear the index')
+            elif args.clear:
+                if not Bup.clear_index():
+                    logging.warning('failed to clear the index')
 
             success = process(args)
     except SystemExit:

--- a/bup_cron/__init__.py
+++ b/bup_cron/__init__.py
@@ -697,6 +697,11 @@ class Pidfile():
                 # not an integer
                 logging.debug("not an integer: %s" % pidstr)
                 return False
+
+            # First check the proc filesystem, which may not be available.
+            if os.path.exists('/proc/%d' % pid):
+                return pid
+
             try:
                 os.kill(pid, 0)
             except OSError:

--- a/bup_cron/__init__.py
+++ b/bup_cron/__init__.py
@@ -1082,15 +1082,15 @@ def main():
 
     logging.info('bup-cron %s starting' % __version__)
     try:
-        if not os.path.exists(os.environ['BUP_DIR']):
-            if not Bup.init(args.remote):
-                bail(3, timer, 'failed to initialize bup repo')
-        else:
-            if args.clear:
-                if not Bup.clear_index():
-                    logging.warning('failed to clear the index')
-
         with Pidfile(args.pidfile):
+            if not os.path.exists(os.environ['BUP_DIR']):
+                if not Bup.init(args.remote):
+                    bail(3, timer, 'failed to initialize bup repo')
+            else:
+                if args.clear:
+                    if not Bup.clear_index():
+                        logging.warning('failed to clear the index')
+
             success = process(args)
     except SystemExit:
         return

--- a/bup_cron/__init__.py
+++ b/bup_cron/__init__.py
@@ -704,9 +704,15 @@ class Pidfile():
 
             try:
                 os.kill(pid, 0)
-            except OSError:
-                logging.debug("can't deliver signal to %s" % pid)
-                return False
+            except OSError as e:
+                if e.errno == errno.ESRCH:
+                    # Not running
+                    logging.debug("process %d is not running" % pid)
+                    return False
+                elif e.errno == errno.EPERM:
+                    # No permission to signal this process!
+                    logging.debug("can't deliver signal to process %d" % pid)
+                    return pid
             else:
                 return pid
 


### PR DESCRIPTION
I've ran bup-cron with `sudo` and then tried to run it as a normal user, too:

    configured stdout level 10
    bup-cron 1.3 starting
    locking pidfile /mnt/backup/localhost.bup-cron/.bup-cron.pid
    can't deliver signal to 30333
    removed staled lockfile /mnt/backup/localhost.bup-cron/.bup-cron.pid
    ...

Additionally, init and clear were not covered/protected by the pidfile.
